### PR TITLE
Fix path to JavaFX to build on Mac OS.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,8 @@ libraryDependencies ++= Seq(
   "org.scalatest" % "scalatest_2.10" % "2.0.M5b" % "test")
 
 
-unmanagedJars in Compile += Attributed.blank(file(System.getenv("JAVA_HOME") + "/jre/lib/jfxrt.jar"))
+unmanagedJars in Compile += Attributed.blank(
+    file(scala.util.Properties.javaHome) / "lib" / "jfxrt.jar")
 
 
 jarName in assembly := "slidingPuzzle.jar"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.12.2
+sbt.version=0.12.3


### PR DESCRIPTION
I don't know why there should be a platform dependency. I have not checked other platforms. I am running Mac OS X Mountain Lion and Java 7:

``` console
$ java -version
java version "1.7.0_21"
Java(TM) SE Runtime Environment (build 1.7.0_21-b12)
Java HotSpot(TM) 64-Bit Server VM (build 23.21-b01, mixed mode)
```
